### PR TITLE
avoiding divide by zero warning from tensorflow

### DIFF
--- a/ai_utils/metrics/__init__.py
+++ b/ai_utils/metrics/__init__.py
@@ -38,7 +38,7 @@ def fac2(y_true, y_pred, to_numpy=False):
     min_ = 0.5
     max_ = 2
 
-    division = tf.divide(y_pred, y_true)
+    division = tf.math.divide_no_nan(y_pred, y_true)
 
     greater_min = tf.greater_equal(division, min_)
     less_max = tf.less_equal(division, max_)


### PR DESCRIPTION
When y_true has any zero, a warning is appearing.

`/usr/lib/python3.7/site-packages/tensorflow_core/python/ops/math_ops.py:325: RuntimeWarning: divide by zero encountered in true_divide
  return x / y`

The method `tf.math.divide_no_nan` can be used to return zero in the division if the denominator is zero.

ref: https://www.tensorflow.org/api_docs/python/tf/math/divide_no_nan